### PR TITLE
Install pipenv via pip

### DIFF
--- a/cmd/brew-bootstrap-pyenv-python
+++ b/cmd/brew-bootstrap-pyenv-python
@@ -88,8 +88,8 @@ if [ "$(pyenv exec python --version)" != "$(python --version)" ]; then
   abort_with_shell_setup_message
 fi
 
-(which pipenv &>/dev/null) || {
-  brew install pipenv
+(pipenv --version &>/dev/null) || {
+  pip install pipenv
 }
 pipenv install
 


### PR DESCRIPTION
Installing via `brew` didn't seem to properly respect the currently used python.

I also thought that we could just improve the check for the existence of `pipenv` from `which pipenv`, which seems to return `0` even when `pipenv` is not actually installed in current python version:
```bash
$ which pipenv; echo $?
/Users/honza/.pyenv/shims/pipenv
0
$ pipenv --version; echo $?
pyenv: pipenv: command not found

The `pipenv' command exists in these Python versions:
  3.6.3
  3.6.6

127
```
But using `brew install` manually in such situation didn't seem to help. Brew reported `pipenv` to be already installed (probably in different python version).

I think using `pip` should help as this should correctly install `pipenv` to the current python.

Changing the installation check is IMO also needed to avoid installation being skipped when `pipenv` exists in different python version.