### PR TITLE
Use homebrew for pipenv

### DIFF
--- a/cmd/brew-bootstrap-pyenv-python
+++ b/cmd/brew-bootstrap-pyenv-python
@@ -91,6 +91,11 @@ fi
 (which pipenv &>/dev/null) || {
   brew install pipenv
 }
+
+if ! env | grep ^PIPENV_PYTHON= > /dev/null; then
+  abort 'Error: add `export PIPENV_PYTHON=$PYENV_ROOT/shims/python` to the end of your .bash_profile!'
+fi
+
 pipenv install
 
 EXPECTED_EXIT="1"

--- a/cmd/brew-bootstrap-pyenv-python
+++ b/cmd/brew-bootstrap-pyenv-python
@@ -73,7 +73,7 @@ if ! pyenv version-name &>/dev/null; then
     PYTHON_DEFINITION="$BASE_PATH/python-definitions/$PYTHON_REQUESTED"
 
     if ! [ -f "$PYTHON_DEFINITION" ]; then
-      warn  "Error: cannot find Ruby $PYTHON_REQUESTED definition in python-build or at:"
+      warn  "Error: cannot find Python $PYTHON_REQUESTED definition in python-build or at:"
       abort "$PYTHON_DEFINITION"
     fi
   fi

--- a/cmd/brew-bootstrap-pyenv-python
+++ b/cmd/brew-bootstrap-pyenv-python
@@ -93,7 +93,7 @@ fi
 }
 
 if ! env | grep ^PIPENV_PYTHON= > /dev/null; then
-  abort 'Error: add `export PIPENV_PYTHON=$PYENV_ROOT/shims/python` to the end of your .bash_profile!'
+  abort 'Error: add `export PIPENV_PYTHON=$PYENV_ROOT/shims/python` to the end of your .bash_profile! If `$PYENV_ROOT` is not set, use `$(pyenv root)` instead.'
 fi
 
 pipenv install

--- a/cmd/brew-bootstrap-pyenv-python
+++ b/cmd/brew-bootstrap-pyenv-python
@@ -88,8 +88,8 @@ if [ "$(pyenv exec python --version)" != "$(python --version)" ]; then
   abort_with_shell_setup_message
 fi
 
-(pipenv --version &>/dev/null) || {
-  pip install pipenv
+(which pipenv &>/dev/null) || {
+  brew install pipenv
 }
 pipenv install
 


### PR DESCRIPTION
After a discussion in #1 it seemed everyone was onboard with switching this project to go back to rely on the homebrew installed Pipenv. The reasons for this are outlined in PR #1, but basically the gist is:

* A homebrew installed pipenv is installed in it's own isolated environment. That means it's globally available but doesn't interfere with any other Python install.
* Most projects using Python should be using pipenv and we've already settled on `pyenv` as a python version manager. As long as the user sets `PIPENV_PYTHON=$PYENV_ROOT/shims/python` (may need to use `$(pyenv root)` instead of `$PYENV_ROOT`) then pipenv will "do the right thing" by using the current pyenv python.