### PR TITLE
Better Python Version Check

### DIFF
--- a/cmd/brew-bootstrap-pyenv-python
+++ b/cmd/brew-bootstrap-pyenv-python
@@ -92,8 +92,8 @@ fi
   brew install pipenv
 }
 
-if ! env | grep ^PIPENV_PYTHON= > /dev/null; then
-  abort 'Error: add `export PIPENV_PYTHON=$PYENV_ROOT/shims/python` to the end of your .bash_profile! If `$PYENV_ROOT` is not set, use `$(pyenv root)` instead.'
+if [ "$(pyenv exec python --version)" != "$(python --version)" ]; then
+  abort_with_shell_setup_message
 fi
 
 pipenv install


### PR DESCRIPTION
Based on the work from #2, I found that I would always hit this abort here. I did some local hacking on `/usr/local/Homebrew/Library/Taps/customink/homebrew-bootstrap-python/cmd/brew-bootstrap-pyenv-python` and found that Homebrew executes these cmd files in a sub shell. So the `env` check had mostly `HOMEBREW_*` stuff. I did confirm that this pattern RJ recommended from rbenv's homebrew bootstrap did work tho.