### PR TITLE
Fix incorrect PYTHON_VERSION check remove pipenv install

### DIFF
--- a/cmd/brew-bootstrap-pyenv-python
+++ b/cmd/brew-bootstrap-pyenv-python
@@ -96,7 +96,5 @@ if [ "$(pyenv exec python --version)" != "$(python --version)" ]; then
   abort_with_shell_setup_message
 fi
 
-pipenv install
-
 EXPECTED_EXIT="1"
 exit 0

--- a/cmd/brew-bootstrap-pyenv-python
+++ b/cmd/brew-bootstrap-pyenv-python
@@ -62,8 +62,8 @@ if ! which pyenv &>/dev/null; then
 fi
 
 if ! pyenv version-name &>/dev/null; then
-  if ! [[ -z "$RBENV_VERSION" ]]; then
-    PYTHON_REQUESTED="$RBENV_VERSION"
+  if ! [[ -z "$PYENV_VERSION" ]]; then
+    PYTHON_REQUESTED="$PYENV_VERSION"
   else
     PYTHON_REQUESTED="$(pyenv local)"
   fi


### PR DESCRIPTION
### Description

While trying to use this tap I kept running into some strange errors that made it seem like the process was failing. I was able to narrow it down to a single line and noticed everything up until this point was being installed successfully. 

At the end the tap tries to run `pipenv install` which is the equivalent of running `bundle install` and that would throw an error and crash. This command is meant to be run in each project to install the packages the application needs, which is to be executed through `bin/setup`. 

I also discovered an incorrect pyenv version check was being used before it tries to install the proper python version. `$RBENV_VERSION` was being checked instead of `$PYENV_VERSION`. Even though this was not causing problems for me I wanted to get that fixed as to prevent issues for others. 

### Changes

Replaced `$RBENV_VERSION` with `$PYENV_VERSION`. 
Removed `pipenv install` from the script.

### Notes

Tested this locally by altering the tap file in my `Homebrew/Library/Taps/` removing the `pipenv install` prevent any errors from being thrown and the updated `$PYENV_VERSION` check works as intended.
